### PR TITLE
Implement wrapper for L.icon()

### DIFF
--- a/pyqtlet2/leaflet/__init__.py
+++ b/pyqtlet2/leaflet/__init__.py
@@ -2,6 +2,7 @@ from .map import Map
 from .layer import LayerGroup, FeatureGroup, imageOverlay
 from .layer.tile import TileLayer
 from .layer.marker import Marker
+from .layer.icon import Icon
 from .layer.vector import Circle, CircleMarker, Polygon, Polyline, Rectangle
 from .control import Control
 
@@ -13,6 +14,7 @@ class L:
     tileLayer = TileLayer
     imageOverlay = imageOverlay
     marker = Marker
+    icon = Icon
     circleMarker = CircleMarker
     polyline = Polyline
     polygon = Polygon

--- a/pyqtlet2/leaflet/layer/icon/__init__.py
+++ b/pyqtlet2/leaflet/layer/icon/__init__.py
@@ -1,0 +1,1 @@
+from .icon import Icon

--- a/pyqtlet2/leaflet/layer/icon/icon.py
+++ b/pyqtlet2/leaflet/layer/icon/icon.py
@@ -1,0 +1,17 @@
+from ..layer import Layer
+from pyqtlet2.leaflet.core.Parser import Parser
+
+
+class Icon(Layer):
+    def __init__(self, iconUrl: str, options=None):
+        super().__init__()
+        if isinstance(options, type(None)):
+            options = {}
+        self.iconUrl = iconUrl
+        self.options = options
+        self._initJs()
+
+    def _initJs(self):
+        leafletJsObject = 'L.icon({options});'.format(options=Parser.dict_for_js({"iconUrl": self.iconUrl,
+                                                                                  **self.options}))
+        self._createJsObject(leafletJsObject)

--- a/pyqtlet2/leaflet/layer/icon/icon.py
+++ b/pyqtlet2/leaflet/layer/icon/icon.py
@@ -1,5 +1,6 @@
 from ..layer import Layer
 from pyqtlet2.leaflet.core.Parser import Parser
+import os
 
 
 class Icon(Layer):
@@ -8,8 +9,19 @@ class Icon(Layer):
         if isinstance(options, type(None)):
             options = {}
         self.iconUrl = iconUrl
+        self.icon_found = False
         self.options = options
+        self._check_icon_url()
         self._initJs()
+
+    def _check_icon_url(self):
+        if "http" in self.iconUrl:
+            self._log.info("Can't check if icon exists at url!")
+            return
+        if not os.path.isfile(self.iconUrl):
+            self._log.error(f"Can't locate file at path: '{self.iconUrl}'. Current working directory is '{os.getcwd()}'")
+            return
+        self.icon_found = True
 
     def _initJs(self):
         leafletJsObject = 'L.icon({options});'.format(options=Parser.dict_for_js({"iconUrl": self.iconUrl,

--- a/pyqtlet2/leaflet/layer/layer.py
+++ b/pyqtlet2/leaflet/layer/layer.py
@@ -1,4 +1,5 @@
 from ..core import Evented
+import logging
 
 class Layer(Evented):
 
@@ -30,6 +31,7 @@ class Layer(Evented):
         super().__init__()
         self._map = None
         self._layerName = self._getNewLayerName()
+        self._log = logging.getLogger(f"layer_{self._layerName}")
 
     def _getNewLayerName(self):
         layerName = 'l{}'.format(self.layerId)

--- a/pyqtlet2/leaflet/layer/marker/marker.py
+++ b/pyqtlet2/leaflet/layer/marker/marker.py
@@ -1,4 +1,5 @@
 from ..layer import Layer
+from ..icon import Icon
 from pyqtlet2.leaflet.core.Parser import Parser
 from PyQt5.QtCore import pyqtSlot, pyqtSignal, QJsonValue
 
@@ -64,4 +65,8 @@ class Marker(Layer):
         self.draggable = draggable
         option = 'enable' if self.draggable else 'disable'
         js = '{layerName}.dragging.{option}();'.format(layerName=self._layerName, option=option)
+        self.runJavaScript(js)
+
+    def setIcon(self, icon: Icon):
+        js = '{layerName}.setIcon({markerIcon});'.format(layerName=self._layerName, markerIcon=icon._layerName)
         self.runJavaScript(js)

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'pyqtlet2.leaflet.layer.marker',
         'pyqtlet2.leaflet.layer.tile',
         'pyqtlet2.leaflet.layer.vector',
+        'pyqtlet2.leaflet.layer.icon',
         'pyqtlet2.leaflet.map',
     ],
     package_data={


### PR DESCRIPTION
## What was done
Created the functionallity to use L.icon. This allows the user to add custom icons to a marker. The icon can either be provided by a an URL or by an file-path. This closes #3 

You can use all options which are provided by leaflet (see [documentation](https://leafletjs.com/reference.html#icon))

## Example usage
1. Create an icon
```lang=python
# Local file path
icon_url = os.path.join(os.getcwd(), "pyqtle/web/modules/leaflet_171/images/marker-icon.png")
# Remote url
icon_url = "https://leafletjs.com/examples/custom-icons/leaf-red.png"

self.red_icon = L.icon(iconUrl=icon_url, options={
    "iconSize": [38, 95],
    "iconAnchor": [22, 94],
})
```
2. Add the icon to the marker
```lang=python
self.marker.setIcon(self.red_icon)
```