### PR TITLE
feature: add `return self` wherever sensible

### DIFF
--- a/pyqtlet2/leaflet/layer/layer.py
+++ b/pyqtlet2/leaflet/layer/layer.py
@@ -40,9 +40,11 @@ class Layer(Evented):
 
     def addTo(self, map_):
         map_.addLayer(self)
+        return self
 
     def removeFrom(self, map_):
         map_.removeLayer(self)
+        return self
 
     def bindPopup(self, content, options=None):
         js = '{layerName}.bindPopup("{content}"'.format(
@@ -51,10 +53,12 @@ class Layer(Evented):
             js += ', {options}'.format(self._stringifyForJs(options))
         js += ')'
         self.runJavaScript(js)
-        
+        return self
+
     def unbindPopup(self):
         js = '{layerName}.unbindPopup()'.format(layerName=self._layerName)
         self.runJavaScript(js)
+        return self
 
     def bindTooltip(self, content, options=None):
         js = '{layerName}.bindTooltip("{content}"'.format(
@@ -63,9 +67,11 @@ class Layer(Evented):
             js += ', {options}'.format(self._stringifyForJs(options))
         js += ')'
         self.runJavaScript(js)
-        
+        return self
+
     def unbindTooltip(self):
         js = '{layerName}.unbindTooltip()'.format(layerName=self._layerName)
         self.runJavaScript(js)
+        return self
 
 

--- a/pyqtlet2/leaflet/layer/marker/marker.py
+++ b/pyqtlet2/leaflet/layer/marker/marker.py
@@ -55,19 +55,23 @@ class Marker(Layer):
         js = '{layerName}.setLatLng({latLng})'.format(
                 layerName=self._layerName, latLng=latLng)
         self.runJavaScript(js)
+        return self
 
     def setOpacity(self, opacity):
         self.opacity = opacity
         js = '{layerName}.setOpacity({opacity})'.format(
                 layerName=self._layerName, opacity=self.opacity)
         self.runJavaScript(js)
+        return self
 
     def setDragging(self, draggable):
         self.draggable = draggable
         option = 'enable' if self.draggable else 'disable'
         js = '{layerName}.dragging.{option}();'.format(layerName=self._layerName, option=option)
         self.runJavaScript(js)
+        return self
 
     def setIcon(self, icon: Icon):
         js = '{layerName}.setIcon({markerIcon});'.format(layerName=self._layerName, markerIcon=icon._layerName)
         self.runJavaScript(js)
+        return self

--- a/pyqtlet2/leaflet/map/map.py
+++ b/pyqtlet2/leaflet/map/map.py
@@ -103,12 +103,14 @@ class Map(Evented):
             js += ', {options}'.format(options=options)
         js += ');'
         self.runJavaScript(js)
+        return self
 
     def addLayer(self, layer):
         self._layers.append(layer)
         layer.map = self
         js = 'map.addLayer({layerName})'.format(layerName=layer.layerName)
         self.runJavaScript(js)
+        return self
 
     def removeLayer(self, layer):
         if layer not in self._layers:
@@ -118,12 +120,14 @@ class Map(Evented):
         layer.map = None
         js = 'map.removeLayer({layerName})'.format(layerName=layer.layerName)
         self.runJavaScript(js)
+        return self
 
     def addControl(self, control):
         self._controls.append(control)
         control.map = self
         js = 'map.addControl({controlName})'.format(controlName=control.controlName)
         self.runJavaScript(js)
+        return self
 
     def removeControl(self, control):
         if control not in self._controls:
@@ -133,6 +137,7 @@ class Map(Evented):
         control.map = None
         js = 'map.removeControl({controlName})'.format(controlName=control.controlName)
         self.runJavaScript(js)
+        return self
 
     def getBounds(self, callback):
         return self.getJsResponse('map.getBounds()', callback)
@@ -155,22 +160,27 @@ class Map(Evented):
             js += ', {options}'.format(options=options)
         js += ');'
         self.runJavaScript(js)
+        return self
 
     def setMaxBounds(self, bounds):
         js = 'map.setMaxBounds({bounds})'.format(bounds=bounds)
         self.runJavaScript(js)
+        return self
 
     def fitBounds(self, bounds):
         js = 'map.fitBounds({bounds})'.format(bounds=bounds)
         self.runJavaScript(js)
+        return self
 
     def setMaxZoom(self, zoom):
         js = 'map.setMaxZoom({zoom})'.format(zoom=zoom)
         self.runJavaScript(js)
+        return self
 
     def setMinZoom(self, zoom):
         js = 'map.setMinZoom({zoom})'.format(zoom=zoom)
         self.runJavaScript(js)
+        return self
 
     def panTo(self, latLng, options=None):
         js = 'map.panTo({latLng}'.format(latLng=latLng)
@@ -178,6 +188,7 @@ class Map(Evented):
             js += ', {options}'.format(options=options)
         js += ');'
         self.runJavaScript(js)
+        return self
 
     def flyTo(self, latLng, zoom=None, options=None):
         js = 'map.flyTo({latLng}'.format(latLng=latLng)
@@ -187,4 +198,4 @@ class Map(Evented):
             js += ', {options}'.format(options=options)
         js += ');'
         self.runJavaScript(js)
-
+        return self


### PR DESCRIPTION
Add `return self` wherever sensible to allow call chaining (Javascript-style).

This commit does not change current behavior at all.
`return self` statement was only added to methods not having an explicit `return statement.`

I added a few more returns than I actually need to cover other possible usages.