### PR TITLE
Feature: rotated marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ if __name__ == '__main__':
     sys.exit(app.exec_())
 ```
 
+## Addtional Leaflet Packages
+- Leaflet.draw (Version 0.4.14) - https://github.com/Leaflet/Leaflet.draw
+- Leaflet.RotatedMarker (Version 0.2.0) - https://github.com/bbecquet/Leaflet.RotatedMarker
+
 ## Using Unimplemented Leaflet Features
 At this time, there is noone actively adding features to pyqtlet. This means that there
 are a lot of Leaflet features that are not implemented in pyqtlet. However, there is still

--- a/pyqtlet2/leaflet/layer/marker/marker.py
+++ b/pyqtlet2/leaflet/layer/marker/marker.py
@@ -15,7 +15,7 @@ class Marker(Layer):
             options = {}
         self.latLng = latLng
         self.options = options
-        self.opacity = options.get('opacity', 0)
+        self.opacity = options.get('opacity', 1)
         self.draggable = options.get('draggable', False)
         self._initJs()
         self._connectEventToSignal('move', '_onMove')
@@ -73,5 +73,15 @@ class Marker(Layer):
 
     def setIcon(self, icon: Icon):
         js = '{layerName}.setIcon({markerIcon});'.format(layerName=self._layerName, markerIcon=icon._layerName)
+        self.runJavaScript(js)
+        return self
+
+    def setRotationAngle(self, angle_deg: float):
+        js = '{layerName}.setRotationAngle({angle_deg});'.format(layerName=self._layerName, angle_deg=angle_deg)
+        self.runJavaScript(js)
+        return self
+
+    def setRotationOrigin(self, origin: str):
+        js = '{layerName}.setRotationOrigin({origin});'.format(layerName=self._layerName, origin=origin)
         self.runJavaScript(js)
         return self

--- a/pyqtlet2/web/map.html
+++ b/pyqtlet2/web/map.html
@@ -15,6 +15,7 @@
         <!-- Leaflet JS -->
         <script src='modules/leaflet_171/leaflet.js'></script>
         <script src='modules/leaflet_draw_414/dist/leaflet.draw.js'></script>
+        <script src='modules/leaflet_rotatedMarker_020/leaflet.rotatedMarker.js'></script>
         <!-- Custom JS -->
         <script src='custom.js'></script>
     </body>

--- a/pyqtlet2/web/modules/leaflet_rotatedMarker_020/LICENSE
+++ b/pyqtlet2/web/modules/leaflet_rotatedMarker_020/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Benjamin Becquet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/pyqtlet2/web/modules/leaflet_rotatedMarker_020/README.md
+++ b/pyqtlet2/web/modules/leaflet_rotatedMarker_020/README.md
@@ -1,0 +1,45 @@
+Leaflet Rotated Marker
+===
+
+Enables rotation of marker icons in Leaflet.
+
+Compatible with versions 0.7.* and 1.* of Leaflet. Doesn't work on IE < 9.
+
+```bash
+npm install leaflet-rotatedmarker
+```
+
+Usage
+---
+
+```js
+L.marker([48.8631169, 2.3708919], {
+    rotationAngle: 45
+}).addTo(map);
+```
+
+API
+---
+
+It simply extends the `L.Marker` class with two new options:
+
+Option | Type | Default | Description  
+-------|------|---------|------------
+**`rotationAngle`** | `Number` | 0 | Rotation angle, in degrees, clockwise.
+**`rotationOrigin`** | `String` | `'bottom center'` | The rotation center, as a [`transform-origin`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin) CSS rule.
+
+and two new methods:
+
+Method | Returns | Description
+-------|---------|------------
+**`setRotationAngle(newAngle)`** | `this` | Sets the rotation angle value.
+**`setRotationOrigin(newOrigin)`** | `this` | Sets the rotation origin value.
+
+The default `rotationOrigin` value will rotate around the bottom center point, corresponding to the "tip" of the marker for most commonly used icons. If your marker icon has no tip, or you want to rotate around its center, use `center center`.
+
+Note
+---
+
+On purpose, it doesn't rotate marker icon shadows. Mainly because there is no way to make it look good with the perspective of classic, pin type shadows (anyway, these shadows are so 2005, right?).
+
+So just disable icon shadows, or use simple ones which will work for all marker angles.

--- a/pyqtlet2/web/modules/leaflet_rotatedMarker_020/example.html
+++ b/pyqtlet2/web/modules/leaflet_rotatedMarker_020/example.html
@@ -1,0 +1,41 @@
+﻿<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+
+    <title>Leaflet rotated marker example</title>
+
+    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v1.1.0/leaflet.css" />
+    <style>
+        * { margin: 0; padding: 0; }
+        html, body { height: 100%; }
+        #map { width:100%; height:100%; }
+    </style>
+
+    <script src="http://cdn.leafletjs.com/leaflet/v1.1.0/leaflet-src.js"></script>
+    <script src="leaflet.rotatedMarker.js"></script>
+    <script>
+        window.onload = function() {
+            var map = L.map('map', {
+                center: [48.8631169, 2.3708919],
+                zoom: 8,
+                layers: [
+                    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+                        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+                    })
+                ]
+            });
+
+            var m = L.marker(map.getCenter(), {
+                rotationAngle: 45,
+                draggable: true
+            }).addTo(map);
+        };
+    </script>
+    </head>
+
+    <body>
+        <div id="map"></div>
+    </body>
+</html>

--- a/pyqtlet2/web/modules/leaflet_rotatedMarker_020/leaflet.rotatedMarker.js
+++ b/pyqtlet2/web/modules/leaflet_rotatedMarker_020/leaflet.rotatedMarker.js
@@ -1,0 +1,57 @@
+(function() {
+    // save these original methods before they are overwritten
+    var proto_initIcon = L.Marker.prototype._initIcon;
+    var proto_setPos = L.Marker.prototype._setPos;
+
+    var oldIE = (L.DomUtil.TRANSFORM === 'msTransform');
+
+    L.Marker.addInitHook(function () {
+        var iconOptions = this.options.icon && this.options.icon.options;
+        var iconAnchor = iconOptions && this.options.icon.options.iconAnchor;
+        if (iconAnchor) {
+            iconAnchor = (iconAnchor[0] + 'px ' + iconAnchor[1] + 'px');
+        }
+        this.options.rotationOrigin = this.options.rotationOrigin || iconAnchor || 'center bottom' ;
+        this.options.rotationAngle = this.options.rotationAngle || 0;
+
+        // Ensure marker keeps rotated during dragging
+        this.on('drag', function(e) { e.target._applyRotation(); });
+    });
+
+    L.Marker.include({
+        _initIcon: function() {
+            proto_initIcon.call(this);
+        },
+
+        _setPos: function (pos) {
+            proto_setPos.call(this, pos);
+            this._applyRotation();
+        },
+
+        _applyRotation: function () {
+            if(this.options.rotationAngle) {
+                this._icon.style[L.DomUtil.TRANSFORM+'Origin'] = this.options.rotationOrigin;
+
+                if(oldIE) {
+                    // for IE 9, use the 2D rotation
+                    this._icon.style[L.DomUtil.TRANSFORM] = 'rotate(' + this.options.rotationAngle + 'deg)';
+                } else {
+                    // for modern browsers, prefer the 3D accelerated version
+                    this._icon.style[L.DomUtil.TRANSFORM] += ' rotateZ(' + this.options.rotationAngle + 'deg)';
+                }
+            }
+        },
+
+        setRotationAngle: function(angle) {
+            this.options.rotationAngle = angle;
+            this.update();
+            return this;
+        },
+
+        setRotationOrigin: function(origin) {
+            this.options.rotationOrigin = origin;
+            this.update();
+            return this;
+        }
+    });
+})();

--- a/pyqtlet2/web/modules/leaflet_rotatedMarker_020/package.json
+++ b/pyqtlet2/web/modules/leaflet_rotatedMarker_020/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "leaflet-rotatedmarker",
+    "version": "0.2.0",
+    "description": "Enables rotation of marker icons in Leaflet.",
+    "main": "leaflet.rotatedMarker.js",
+    "repository": {
+        "type": "git",
+        "url": "git@github.com:bbecquet/Leaflet.RotatedMarker.git"
+    },
+    "author": {
+        "name": "Benjamin Becquet",
+        "email": "benjamin.becquet@gmail.com",
+        "url": "http://bbecquet.net"
+    },
+    "license": "MIT"
+}


### PR DESCRIPTION
Extended functionality to use RotatedMarker from https://github.com/bbecquet/Leaflet.RotatedMarker.

You can pass the values through the as `options` or use the two functions on the marker!  
`setRotationAngle()`  
`setRotationOrigin()`

Be aware with custom marker to set the anchor correct!
Good debugging code: 

```python
self.rot_angle = 45
# Two marker at the same postion
self.marker1 = L.marker([12.934056, 77.610029], options={"draggable": "true"})
self.marker2 = L.marker([12.934056, 77.610029], options={"draggable": "true"})
# Set your custom icon to one of the markers
self.marker1.setIcon(self.custom_icon)
# Connect to the moveend event of the other marker
self.marker2.moveend.connect(self.marker_moved)
# Add both marker to the map
self.map.addLayer(self.marker1)
self.map.addLayer(self.marker2)

def marker_moved(self, kwargs: dict = None):
    self.marker1.setLatLng(kwargs.get("latLng"))
    self.rot_angle = (self.rot_angle + 90) % 360
    self.marker1.setRotationAngle(self.rot_angle)
```