### PR TITLE
feature: implement qtpy

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -10,7 +10,7 @@ package.
 .. code:: python
 
 	import sys
-	from PyQt5.QtWidgets import QApplication, QVBoxLayout, QWidget
+	from qtpy.QtWidgets import QApplication, QVBoxLayout, QWidget
 	from pyqtlet import L, MapWidget
 
 

--- a/pyqtlet2/__init__.py
+++ b/pyqtlet2/__init__.py
@@ -3,13 +3,7 @@ Bringing Leaflet maps to PyQt.
 """
 
 __author__ = 'Leon Friedmann <leon.friedmann@tum.de>'
-__version__ = '0.7.0'
-import sys
-
-if 'PySide6' in sys.modules:
-    API = 'PySide6'
-else:
-    API = 'PyQt5'
+__version__ = '0.8.0'
 
 from .mapwidget import MapWidget
 from .leaflet import L

--- a/pyqtlet2/leaflet/control/control.py
+++ b/pyqtlet2/leaflet/control/control.py
@@ -3,15 +3,7 @@ import logging
 import os
 import time
 
-from ... import API
-
-if API == 'PyQt5':
-    from PyQt5.QtCore import pyqtSlot, pyqtSignal
-else:
-    from PySide6.QtCore import Slot, Signal
-    pyqtSlot = Slot
-    pyqtSignal = Signal
-
+from qtpy.QtCore import Slot, Signal
 from ..core import Evented
 
 class Control(Evented):
@@ -21,8 +13,8 @@ class Control(Evented):
     controlId = 0
     # addedToMap and removedFromMap are signals for controls to
     # know when they're added and removed from maps
-    addedToMap = pyqtSignal()
-    removedFromMap = pyqtSignal()
+    addedToMap = Signal()
+    removedFromMap = Signal()
 
     @property
     def map(self):

--- a/pyqtlet2/leaflet/core/evented.py
+++ b/pyqtlet2/leaflet/core/evented.py
@@ -1,12 +1,9 @@
 import logging
 import time
 
-from ... import API, mapwidget
+from ... import mapwidget
 
-if API == 'PyQt5':
-    from PyQt5.QtCore import QObject, QJsonValue
-else:
-    from PySide6.QtCore import QObject, QJsonValue
+from qtpy.QtCore import QObject, QJsonValue
 
 
 class Evented(QObject):

--- a/pyqtlet2/leaflet/layer/marker/marker.py
+++ b/pyqtlet2/leaflet/layer/marker/marker.py
@@ -2,21 +2,15 @@ from ..layer import Layer
 from ..icon import Icon
 from ...core.Parser import Parser
 
-from .... import API
-
-if API == 'PyQt5':
-    from PyQt5.QtCore import pyqtSlot, pyqtSignal, QJsonValue
-else:
-    from PySide6.QtCore import Slot, Signal, QJsonValue
-    pyqtSlot, pyqtSignal = Slot, Signal
+from qtpy.QtCore import Slot, Signal, QJsonValue
 
 from typing import List
 
 
 class Marker(Layer):
-    moveend = pyqtSignal(dict)
-    move = pyqtSignal(dict)
-    click = pyqtSignal(dict)
+    moveend = Signal(dict)
+    move = Signal(dict)
+    click = Signal(dict)
 
     def __init__(self, latLng: List[float], options=None):
         super().__init__()
@@ -31,21 +25,21 @@ class Marker(Layer):
         self._connectEventToSignal('moveend', '_onMoveend')
         self._connectEventToSignal('click', '_click')
 
-    @pyqtSlot(QJsonValue)
+    @Slot(QJsonValue)
     def _onMove(self, event):
         self._logger.debug('marker moved. event: {event}'.format(event=event))
         event = self._qJsonValueToDict(event)
         self.latLng = [event["latlng"]["lat"], event["latlng"]["lng"]]
         self.move.emit(event)
 
-    @pyqtSlot(QJsonValue)
+    @Slot(QJsonValue)
     def _onMoveend(self, event):
         self._logger.debug('marker moved. event: {event}'.format(event=event))
         if self.opacity == 0:
             return
         self.moveend.emit({**self._qJsonValueToDict(event), "latLng": self.latLng, "sender": self})
 
-    @pyqtSlot(QJsonValue)
+    @Slot(QJsonValue)
     def _click(self, event):
         self._logger.debug('marker clicked. event: {event}'.format(event=event))
         if self.opacity == 0:

--- a/pyqtlet2/leaflet/map/map.py
+++ b/pyqtlet2/leaflet/map/map.py
@@ -3,14 +3,7 @@ import logging
 import os
 import time
 
-from ... import API
-
-if API == 'PyQt5':
-    from PyQt5.QtCore import pyqtSlot, pyqtSignal, QJsonValue
-else:
-    from PySide6.QtCore import Slot, Signal, QJsonValue
-    pyqtSignal = Signal
-    pyqtSlot = Slot
+from qtpy.QtCore import Slot, Signal, QJsonValue
 
 from ... import mapwidget
 from ..core import Evented
@@ -34,9 +27,9 @@ class Map(Evented):
     :param dict options: Options for initiation (optional)
     '''
 
-    clicked = pyqtSignal(dict)
-    zoom = pyqtSignal(dict)
-    drawCreated = pyqtSignal(dict)
+    clicked = Signal(dict)
+    zoom = Signal(dict)
+    drawCreated = Signal(dict)
 
     @property
     def layers(self):
@@ -52,17 +45,17 @@ class Map(Evented):
         '''
         return self._jsName
 
-    @pyqtSlot(QJsonValue)
+    @Slot(QJsonValue)
     def _onClick(self, event):
         self._logger.debug('map clicked. event: {event}'.format(event=event))
         self.clicked.emit(self._qJsonValueToDict(event))
 
-    @pyqtSlot(QJsonValue)
+    @Slot(QJsonValue)
     def _onDrawCreated(self, event):
         self._logger.debug('draw created. event: {event}'.format(event=event))
         self.drawCreated.emit(self._qJsonValueToDict(event))
 
-    @pyqtSlot(QJsonValue)
+    @Slot(QJsonValue)
     def _onZoom(self, event):
         self._logger.debug('map zoom. event: {event}'.format(event=event))
         self.zoom.emit(self._qJsonValueToDict(event))

--- a/pyqtlet2/mapwidget.py
+++ b/pyqtlet2/mapwidget.py
@@ -1,19 +1,9 @@
 import os
 import time
 
-from . import API
-
-if API == 'PyQt5':
-    from PyQt5.QtCore import QEventLoop, QObject, Qt, QUrl, pyqtSignal
-    from PyQt5.QtWebChannel import QWebChannel
-    from PyQt5.QtWebEngineWidgets import ( QWebEngineView, QWebEnginePage, QWebEngineSettings, 
-                                       QWebEngineScript )
-    Signal = pyqtSignal
-else:
-    from PySide6.QtCore import QEventLoop, QObject, QUrl, Signal, Qt
-    from PySide6.QtWebChannel import QWebChannel
-    from PySide6.QtWebEngineWidgets import QWebEngineView
-    from PySide6.QtWebEngineCore import QWebEnginePage, QWebEngineSettings, QWebEngineScript
+from qtpy.QtCore import QEventLoop, QObject, Qt, QUrl, Signal
+from qtpy.QtWebChannel import QWebChannel
+from qtpy.QtWebEngineWidgets import QWebEngineView, QWebEnginePage, QWebEngineSettings
 
 
 class MapWidget(QWebEngineView):
@@ -52,5 +42,5 @@ class MapWidget(QWebEngineView):
         init_loop = QEventLoop()
         self._page.loadFinished.connect(init_loop.quit)
         self._page.load(QUrl().fromLocalFile(html_path))
-        init_loop.exec()
+        init_loop.exec_()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-PyQt5==5.15.5
-PyQtWebEngine==5.15.5
+QtPy>=2.0.1

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ with open("README.md", "r") as f:
 
 setup(
     name='pyqtlet2',
-    version='0.7.0',
-    description='Bringing leaflet maps to PyQt',
+    version='0.8.0',
+    description='Bringing leaflet maps to Python Qt bindings',
     long_description=long_description,
     long_description_content_type="text/markdown",
     author='Leon Friedmann',
     author_email='leon.friedmann@tum.de',
     url='https://github.com/JaWeilBaum/pyqtlet2',
-    keywords='leaflet, pyqt, maps, python, python3',
+    keywords='leaflet, qtpy, maps, python, python3',
     classifiers=[],
     packages=[
         'pyqtlet2',
@@ -35,9 +35,14 @@ setup(
         ],
     },
     install_requires=[
-        'PyQt5==5.15.5',
-        'PyQtWebEngine==5.15.5'
+        'QtPy>=2.0.1'
     ]
+    extras_require = {
+        'PyQt5' : ['PyQt5>=5.15.5','PyQtWebEngine>=5.15.5'],
+        'PyQt6' : ['PyQt6>=6.2.0','PyQt6-WebEngine>=6.2.0'],
+        'PySide2': ['PySide2'],
+        'PySide6': ['PySide6']
+    }
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     },
     install_requires=[
         'QtPy>=2.0.1'
-    ]
+    ],
     extras_require = {
         'PyQt5' : ['PyQt5>=5.15.5','PyQtWebEngine>=5.15.5'],
         'PyQt6' : ['PyQt6>=6.2.0','PyQt6-WebEngine>=6.2.0'],

--- a/tests/test_layer_elements.py
+++ b/tests/test_layer_elements.py
@@ -2,10 +2,7 @@ import unittest
 import sys
 from pyqtlet2 import L, MapWidget, API
 
-if API == 'PyQt5:
-    from PyQt5.QtWidgets import QApplication
-else:
-    from PyQt6.QtWidgets import QApplication
+from qtpy.QtCore import Slot, Signal, QJsonValue
 
 app = QApplication(sys.argv)
 


### PR DESCRIPTION
I've made the changes to support the generic wrapper `qtpy`:
* drop hard requirements for `PyQt5`. Instead the user  can install the optional dependencies for each Qt binding (for example ``pip install pyqtlet2[PyQt5]``
* if multiple Qt bindings are installed the user needs to set the `qtpy` environment variable before importing `pyqtlet2` (for example ``os.environ["QT_API"] = "pyqt5"`` (see https://github.com/spyder-ide/qtpy/blob/36315655a04ee2197f842f0b5f3d4609489b1c7e/qtpy/__init__.py#L9)

I was able to run the demo code on all Qt bindings supported by ``qtpy``