### PR TITLE
Fix popup and tooltip binding

### DIFF
--- a/pyqtlet2/__init__.py
+++ b/pyqtlet2/__init__.py
@@ -3,7 +3,7 @@ Bringing Leaflet maps to PyQt.
 """
 
 __author__ = 'Leon Friedmann <leon.friedmann@tum.de>'
-__version__ = '0.9.1'
+__version__ = '0.9.2'
 
 from .mapwidget import MapWidget
 from .leaflet import L

--- a/pyqtlet2/leaflet/layer/layer.py
+++ b/pyqtlet2/leaflet/layer/layer.py
@@ -33,13 +33,31 @@ class Layer(Evented):
         raise NotImplemented
 
     def runJavaScriptForMapIndex(self, js):
-        self.runJavaScript(js, self._map.mapWidgetIndex)
+        if self._map is not None:
+            self.runJavaScript(js, self._map.mapWidgetIndex)
 
     def __init__(self):
         super().__init__()
         self._map = None
         self._layerName = self._getNewLayerName()
         self._log = logging.getLogger(f"layer_{self._layerName}")
+        self._popup = None
+        self._popupOptions = None
+        self._tooltip = None
+        self._tooltipOptions = None
+
+    def _initPopupAndTooltip(self):
+        if self._popup is not None:
+            self._bindPopupOrTooltip("Popup", self._popup, self._popupOptions)
+        if self._tooltip is not None:
+            self._bindPopupOrTooltip("Tooltip", self._tooltip, self._tooltipOptions)
+
+    def _bindPopupOrTooltip(self, kind, content, options):
+        js = f'{self._layerName}.bind{kind}("{content}"'
+        if options is not None:
+            js += f', {self._stringifyForJs(options)}'
+        js += ')'
+        self.runJavaScriptForMapIndex(js)
 
     def _getNewLayerName(self):
         layerName = 'l{}'.format(self.layerId)
@@ -55,29 +73,27 @@ class Layer(Evented):
         return self
 
     def bindPopup(self, content, options=None):
-        js = '{layerName}.bindPopup("{content}"'.format(
-                layerName=self._layerName, content=content)
-        if options:
-            js += ', {options}'.format(options=self._stringifyForJs(options))
-        js += ')'
-        self.runJavaScriptForMapIndex(js)
+        self._popup = content
+        self._popupOptions = options
+        self._bindPopupOrTooltip("Popup", self._popup, self._popupOptions)
         return self
 
     def unbindPopup(self):
+        self._popup = None
+        self._popupOptions = None
         js = '{layerName}.unbindPopup()'.format(layerName=self._layerName)
         self.runJavaScriptForMapIndex(js)
         return self
 
     def bindTooltip(self, content, options=None):
-        js = '{layerName}.bindTooltip("{content}"'.format(
-                layerName=self._layerName, content=content)
-        if options:
-            js += ', {options}'.format(options=self._stringifyForJs(options))
-        js += ')'
-        self.runJavaScriptForMapIndex(js)
+        self._tooltip = content
+        self._tooltipOptions = options
+        self._bindPopupOrTooltip("Tooltip", self._tooltip, self._tooltipOptions)
         return self
 
     def unbindTooltip(self):
+        self._tooltip = None
+        self._tooltipOptions = None
         js = '{layerName}.unbindTooltip()'.format(layerName=self._layerName)
         self.runJavaScriptForMapIndex(js)
         return self

--- a/pyqtlet2/leaflet/map/map.py
+++ b/pyqtlet2/leaflet/map/map.py
@@ -124,6 +124,7 @@ class Map(Evented):
         layer._initJs()
         js = 'map.addLayer({layerName})'.format(layerName=layer.layerName)
         self.runJavaScriptForMap(js)
+        layer._initPopupAndTooltip()
         return self
 
     def removeLayer(self, layer):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name='pyqtlet2',
-    version='0.9.1',
+    version='0.9.2',
     description='Bringing leaflet maps to Python Qt bindings',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Starting with 0.9.0, adding a popup or tooltip to a layer before it is added to a map no longer works. Thus, the `README.md` example no longer works too.

This PR fixes this issue by storing the popup, tooltip and their respective options in dedicated attributes and by adding a method to execute the Javascript code once the layer has been added to a map.