### PR TITLE
Fix the creation of layers using draw control

### DIFF
--- a/pyqtlet2/leaflet/layer/layergroup.py
+++ b/pyqtlet2/leaflet/layer/layergroup.py
@@ -21,6 +21,8 @@ class LayerGroup(Layer):
 
     def addLayer(self, layer):
         self._layers.append(layer)
+        layer.map = self._map
+        layer._initJs()
         js = '{layerGroup}.addLayer({layerName})'.format(layerGroup=self._layerName,
                 layerName=layer._layerName)
         self.runJavaScriptForMapIndex(js)

--- a/pyqtlet2/leaflet/layer/vector/circle.py
+++ b/pyqtlet2/leaflet/layer/vector/circle.py
@@ -12,4 +12,4 @@ class Circle(CircleMarker):
         if self.options:
             leafletJsObject += ', {options}'.format(options=self.options)
         leafletJsObject += ')'
-        self._createJsObject(leafletJsObject, self)
+        self._createJsObject(leafletJsObject, self._map.mapWidgetIndex)


### PR DESCRIPTION
Fixes the creation of layers using the drawing control, which was no longer working since the implementation of multiple map support in version 0.9.0.

@JaWeilBaum Thanks for merging my previous PR so quickly. I have not encountered any other issues with multiple maps.