### PR TITLE
Fix LayerGroup.toGeoJSON

### DIFF
--- a/pyqtlet2/leaflet/layer/layer.py
+++ b/pyqtlet2/leaflet/layer/layer.py
@@ -36,6 +36,10 @@ class Layer(Evented):
         if self._map is not None:
             self.runJavaScript(js, self._map.mapWidgetIndex)
 
+    def getJsResponseForMapIndex(self, js, callback):
+        if self._map is not None:
+            self.getJsResponse(js, self._map.mapWidgetIndex, callback)
+
     def __init__(self):
         super().__init__()
         self._map = None

--- a/pyqtlet2/leaflet/layer/layergroup.py
+++ b/pyqtlet2/leaflet/layer/layergroup.py
@@ -39,5 +39,5 @@ class LayerGroup(Layer):
         self.runJavaScriptForMapIndex(js)
     
     def toGeoJSON(self, callback):
-        self.getJsResponse('{layer}.toGeoJSON()'.format(layer=self.jsName), callback)
+        self.getJsResponseForMapIndex(f'{self.jsName}.toGeoJSON()', callback)
 


### PR DESCRIPTION
Error related to multiple maps implementation from 0.9.0+.
The best fix is to use a new `Layer.getJsResponseForMapIndex` similar to `Layer.runJavaScriptForMapIndex`.