### PR TITLE
Fix the creation of circlemarker using draw control

### DIFF
--- a/pyqtlet2/leaflet/layer/featuregroup.py
+++ b/pyqtlet2/leaflet/layer/featuregroup.py
@@ -31,4 +31,7 @@ class FeatureGroup(LayerGroup):
             coords = drawnLayer['layer']['_latlng']
             radius = drawnLayer['layer']['options']['radius']
             self.addLayer(vector.Circle([coords['lat'], coords['lng']], radius))
+        elif layerType == 'circlemarker':
+            coords = drawnLayer['layer']['_latlng']
+            self.addLayer(vector.CircleMarker([coords['lat'], coords['lng']]))
             


### PR DESCRIPTION
Circle markers did not appear on map when created using draw control because they were not added to the control feature group.